### PR TITLE
docs: 운영 문서 링크 허브를 README에 연결

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,3 @@
 - [업그레이드 의존성/환경값 정합성 정책](docs/upgrade-dependency-env-policy.md)
 - [업그레이드 브랜치/릴리즈/롤백 정책](docs/upgrade-release-policy.md)
 
-## 참고 문서
-- [Repository Guidelines](AGENTS.md)


### PR DESCRIPTION
### 변경 내용\n- README의 운영 가이드 하단에 정책 문서 링크를 추가\n  - Deploy Gate Checklist\n  - 업그레이드 의존성/환경값 정합성 정책\n  - 업그레이드 브랜치/릴리즈/롤백 정책\n  - Repository Guidelines\n\n### 테스트\n- 문서 변경만 반영되므로 코드 실행 영향 없음