### PR TITLE
보안 하위 이슈(#76~#80) 통합 반영

### DIFF
--- a/docs/security-hardening-checklist.md
+++ b/docs/security-hardening-checklist.md
@@ -1,5 +1,12 @@
 # 보안 하드닝 체크리스트 (Issue #29 기반)
 
+## 하위 이슈 반영 상태
+- #76 의존성 취약점 스캔 및 조치 우선순위
+- #77 인증/세션/토큰 처리 방식 점검
+- #78 API 입력 유효성/권한 경계 점검
+- #79 민감정보 노출 및 로그 마스킹 점검
+- #80 배포/CI 보안 가드 정비 검토
+
 ## 실행 전 점검
 - `.env*`에 민감값(`SECRET`, `TOKEN`, `KEY`, `PASSWORD`, `DATABASE_URL`)이 하드코딩되어 있는지 확인
 - 브라우저 노출 가능한 `NEXT_PUBLIC_*` 값에 비밀정보가 없는지 확인
@@ -15,6 +22,21 @@
   - `Cross-Origin-*` 계열 헤더
 - `public` 정적 파일이 필요한 파일만 배포되는지 확인
 
+## 인증/세션 경계
+- 로그인 요청 시 입력값 길이/형식 검증을 수행하고, 실패 시 일반화된 메시지로 응답한다.
+- 세션 상태 체크/로그아웃은 불필요한 토큰 노출 없이 요청 헤더를 최소화한다.
+- 에러 쿼리 파라미터 및 URL 기반 에러 문자열을 사용자 노출 전에 마스킹한다.
+
+## 입력 검증/권한 경계
+- 사용자 입력 기반 JSON 바디는 trim + 타입 정규화 후 서버로 전달한다.
+- 경로 파라미터 사용 구간은 `encodeURIComponent` 등 인코딩 규칙을 일관 적용한다.
+- API 응답 파싱 전 `content-type` 기반 분기와 파싱 실패 예외 처리를 둔다.
+
+## 로그/민감정보 노출 관리
+- `console.*` 사용 시 민감 키워드(`token`, `password`, `authorization`, `cookie`)는 마스킹 처리한다.
+- 예외 메시지/프론트 알림은 원문을 그대로 노출하지 않고, 사용자가 이해 가능한 일반 메시지로 축약한다.
+- API 실패/catch 구간은 로그 수집용 메시지를 유지하되 민감값은 가림 처리한다.
+
 ## 이미지/원격 URL 정책
 - `next.config.mjs`의 `images.remotePatterns`에 허용 도메인만 등록되어 있는지 확인
 - 허용되지 않은 외부 URL은 API/DB 단계에서 차단
@@ -26,12 +48,15 @@
 
 ## 의존성 취약점 점검 절차
 - 정기 실행 명령:
-  - `npm run check:security-audit`
+  - `npm run check:security:report`
   - `npm run check:deps-compat`
-  - `npm run check:ci`
 - 심각도 기준 대응 우선순위:
   - `high`, `critical`: 즉시 수정/차단 (`P0`, `P1`)
   - `moderate`: 다음 스프린트 내 대응 (`P2`)
+- 보고서 산출:
+  - `docs/security-reports/security-audit-latest.md`
+  - `docs/security-reports/security-audit-latest.json`
+- 고위험 취약점이 있으면 변경이 없어도 PR은 블록하고 증빙 링크를 이슈에 첨부한다.
 - lockfile 변경 규칙:
   - `package-lock.json` 변경은 이슈 승인 후, `npm` 결과 재현 가능 상태(변경된 패키지, 변경 사유, 영향 범위)와 함께 PR에 명시
   - 예시: `curl -I https://<도메인>/ | grep -Ei "content-security-policy|x-frame-options|strict-transport-security|referrer-policy"`
@@ -44,3 +69,11 @@
     기대값: Exit code 0
   - 예시: `npm run lint`  
     기대값: Exit code 0
+
+## 배포/CI 보안 가드
+- `.github/workflows/security-audit.yml`를 통해 PR/정기 스케줄에서 보안 게이트를 수행한다.
+- 최소 게이트 명령:
+  - `npm run lint`
+  - `npm run check:security:report`
+  - `npm run check:deps-compat`
+- PR 본문/이슈에 증빙 파일 경로(`docs/security-reports/...`)를 남긴다.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "check:pr-gate": "npm run lint && npm run typecheck && npm run build",
     "check:ci": "npm run lint && npm run typecheck && npm run build",
     "check:deps-compat": "node ./scripts/check-deps-compat.js",
+    "check:security:report": "node ./scripts/security-audit.mjs",
+    "check:security:gate": "npm run lint && npm run check:security:report && npm run check:deps-compat",
     "check:deploy-gate": "powershell -ExecutionPolicy Bypass -File .\\scripts\\p0-deploy-gate.ps1",
     "check:p0-smoke": "powershell -ExecutionPolicy Bypass -File .\\scripts\\p0-smoke-tests.ps1",
     "check:upgrade-regression": "npm run lint && npm run build && npm run check:p0-smoke",

--- a/scripts/security-audit.mjs
+++ b/scripts/security-audit.mjs
@@ -1,0 +1,94 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const OUTPUT_DIR = resolve(process.cwd(), "docs/security-reports");
+const JSON_REPORT_PATH = resolve(OUTPUT_DIR, "security-audit-latest.json");
+const MARKDOWN_REPORT_PATH = resolve(OUTPUT_DIR, "security-audit-latest.md");
+
+function runAuditCommand() {
+    try {
+        const raw = execSync("npm audit --json --omit=dev", { encoding: "utf8" });
+        return { raw, exitCode: 0 };
+    } catch (error) {
+        const stdout = (error.stdout && String(error.stdout)) || "{}";
+        const exitCode = Number(error.status) || 1;
+        return { raw: stdout, exitCode };
+    }
+}
+
+function extractVulnerabilities(audit: unknown) {
+    if (!audit || typeof audit !== "object" || !("vulnerabilities" in audit)) {
+        return [];
+    }
+
+    const vulnerabilities = audit.vulnerabilities;
+    if (!vulnerabilities || typeof vulnerabilities !== "object") {
+        return [];
+    }
+
+    return Object.entries(vulnerabilities).map(([name, detail]) => {
+        if (!detail || typeof detail !== "object") {
+            return { name, severity: "unknown" };
+        }
+
+        const record = detail;
+        return {
+            name,
+            severity: String(record.severity || "unknown"),
+            via: Array.isArray(record.via) ? record.via.length : 0,
+            url: String(record.url || ""),
+        };
+    });
+}
+
+function buildSummary(auditResult, exitCode, vulnerabilities) {
+    const bySeverity = vulnerabilities.reduce((acc, item) => {
+        const severity = String(item.severity || "unknown");
+        acc[severity] = (acc[severity] || 0) + 1;
+        return acc;
+    }, {});
+
+    return {
+        generatedAt: new Date().toISOString(),
+        exitCode,
+        counts: {
+            total: vulnerabilities.length,
+            highOrCritical: (bySeverity.high || 0) + (bySeverity.critical || 0),
+            moderate: bySeverity.moderate || 0,
+        },
+        severities: bySeverity,
+        top: vulnerabilities.filter((item) => item.severity === "high" || item.severity === "critical"),
+    };
+}
+
+function writeReports(summary, rawOutput) {
+    mkdirSync(OUTPUT_DIR, { recursive: true });
+    writeFileSync(JSON_REPORT_PATH, JSON.stringify(summary, null, 2), "utf8");
+    writeFileSync(
+        MARKDOWN_REPORT_PATH,
+        `# Security Audit Report\n\n생성일: ${summary.generatedAt}\n\n- 총 취약점: ${summary.counts.total}\n- High/Critical: ${summary.counts.highOrCritical}\n- Moderate: ${summary.counts.moderate}\n\n## High/Critical 상세\n\n${summary.top.map((item) => `- ${item.name} (${item.severity})`).join("\n")}\n`,
+        "utf8"
+    );
+    writeFileSync(resolve(OUTPUT_DIR, "security-audit-raw.json"), rawOutput, "utf8");
+}
+
+function run() {
+    const { raw, exitCode } = runAuditCommand();
+    let parsed = {};
+    try {
+        parsed = JSON.parse(raw || "{}");
+    } catch {
+        parsed = {};
+    }
+    const vulnerabilities = extractVulnerabilities(parsed);
+    const summary = buildSummary(parsed, exitCode, vulnerabilities);
+    writeReports(summary, raw);
+
+    if (summary.counts.highOrCritical > 0) {
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
+run();

--- a/src/app/(common)/fetchUtils.ts
+++ b/src/app/(common)/fetchUtils.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { AUTH_COOKIE_NAME } from "@/app/(common)/constants";
+import { logWarn } from "./safeLogger";
 
 export type FetchResult<T> = {
     ok: boolean;
@@ -20,7 +21,8 @@ export async function fetchWithCookie<T>(
     };
 
     if (authToken?.value) {
-        headers["Cookie"] = `${cookieName}=${authToken.value}`;
+        const safeCookieName = /^[A-Za-z0-9_-]{1,64}$/.test(cookieName) ? cookieName : AUTH_COOKIE_NAME;
+        headers["Cookie"] = `${safeCookieName}=${authToken.value}`;
     }
 
     try {
@@ -37,6 +39,16 @@ export async function fetchWithCookie<T>(
             };
         }
 
+        const contentType = response.headers.get("content-type") || "";
+        if (!contentType.includes("application/json")) {
+            return {
+                ok: false,
+                data: fallback as T,
+                status: response.status,
+                error: "Unexpected response content type",
+            };
+        }
+
         const text = await response.text();
         if (!text.trim()) {
             return {
@@ -47,11 +59,22 @@ export async function fetchWithCookie<T>(
             };
         }
 
-        const data = JSON.parse(text) as T;
-        return { ok: true, data, status: response.status, error: null };
+        try {
+            const data = JSON.parse(text) as T;
+            return { ok: true, data, status: response.status, error: null };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Invalid JSON response";
+            logWarn("Fetch response json parse failed:", message);
+            return {
+                ok: false,
+                data: fallback as T,
+                status: response.status,
+                error: "Invalid response format",
+            };
+        }
     } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown fetch error";
-        console.error("Fetch failed:", error);
+        logWarn("Fetch failed:", message);
         return {
             ok: false,
             data: fallback as T,

--- a/src/app/(common)/safeLogger.ts
+++ b/src/app/(common)/safeLogger.ts
@@ -1,19 +1,63 @@
 import { isDebugLogEnabled } from "./environment";
 
-export const logDebug = (...args: unknown[]) => {
-    if (isDebugLogEnabled) {
-        console.debug(...args);
+const SENSITIVE_KEYS = [
+    "authorization",
+    "cookie",
+    "password",
+    "token",
+    "secret",
+    "apikey",
+    "apiKey",
+    "session",
+];
+
+function isSensitiveField(field: string): boolean {
+    const lower = field.toLowerCase();
+    return SENSITIVE_KEYS.some((target) => lower.includes(target));
+}
+
+function maskString(value: string): string {
+    return value
+        .replace(/(authorization|x-csrf-token|cookie|password|secret|token|apikey|api[_-]?key)\s*[:=]\s*[^\s,"]+/gi, "$1=***")
+        .replace(/Bearer\s+[A-Za-z0-9._~-]+/gi, "Bearer ***");
+}
+
+function sanitizeArg(value: unknown): unknown {
+    if (value instanceof Error) {
+        return { ...value, message: maskString(value.message) };
     }
+    if (typeof value === "string") {
+        return maskString(value);
+    }
+    if (Array.isArray(value)) {
+        return value.map(sanitizeArg);
+    }
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, nestedValue]) => [
+                key,
+                isSensitiveField(key) ? "***" : sanitizeArg(nestedValue),
+            ])
+        );
+    }
+    return value;
+}
+
+function emitLog(writer: (...args: unknown[]) => void, ...args: unknown[]) {
+    if (!isDebugLogEnabled) {
+        return;
+    }
+    writer(...args.map(sanitizeArg));
+}
+
+export const logDebug = (...args: unknown[]) => {
+    emitLog(console.debug, ...args);
 };
 
 export const logInfo = (...args: unknown[]) => {
-    if (isDebugLogEnabled) {
-        console.info(...args);
-    }
+    emitLog(console.info, ...args);
 };
 
 export const logWarn = (...args: unknown[]) => {
-    if (isDebugLogEnabled) {
-        console.warn(...args);
-    }
+    emitLog(console.warn, ...args);
 };

--- a/src/app/(navigation)/topNavigation.tsx
+++ b/src/app/(navigation)/topNavigation.tsx
@@ -8,6 +8,27 @@ import { BASE_URL } from "../(common)/common";
 import { logWarn } from "../(common)/safeLogger";
 import { useLoginContext } from "../(context)/LoginContext";
 
+function getCsrfTokenValue(cookieHeader: string): string | undefined {
+    const tokenPair = cookieHeader
+        .split("; ")
+        .find((item) => item.startsWith("XSRF-TOKEN="));
+
+    if (!tokenPair) {
+        return undefined;
+    }
+
+    const rawToken = tokenPair.split("=", 2)[1];
+    if (!rawToken) {
+        return undefined;
+    }
+
+    try {
+        return decodeURIComponent(rawToken);
+    } catch {
+        return undefined;
+    }
+}
+
 export function TopNavigation() {
     const [menuToggle, setMenuToggle] = useState(false);
     const { isLogin, setIsLogin } = useLoginContext();
@@ -54,12 +75,11 @@ export function TopNavigation() {
     const handleLogout = async () => {
         try {
             const csrfToken = document.cookie
-                .split("; ")
-                .find((item) => item.startsWith("XSRF-TOKEN="))
-                ?.split("=")[1];
+                ? getCsrfTokenValue(document.cookie)
+                : undefined;
 
             const headers = csrfToken
-                ? { "X-CSRF-Token": decodeURIComponent(csrfToken) }
+                ? { "X-CSRF-Token": csrfToken }
                 : undefined;
 
             const response = await fetch(`${BASE_URL}/logout`, {

--- a/src/app/(user)/join/JoinForm.tsx
+++ b/src/app/(user)/join/JoinForm.tsx
@@ -4,6 +4,51 @@ import { useRouter } from 'next/navigation';
 import React, { useState } from 'react'
 import { logWarn } from '@/app/(common)/safeLogger';
 
+type JoinPayload = {
+    name: string;
+    email: string;
+    password: string;
+};
+
+function trimText(value: string): string {
+    return value.trim();
+}
+
+function buildJoinPayload(formData: FormData): JoinPayload {
+    return {
+        name: trimText(String(formData.get("name") ?? "")),
+        email: trimText(String(formData.get("email") ?? "")),
+        password: String(formData.get("password") ?? ""),
+    };
+}
+
+function isValidJoinResponsePayload(
+    response: unknown,
+): response is { result: { resultCode: number; resultMessage?: string }; body?: string } {
+    if (!response || typeof response !== "object" || response === null) {
+        return false;
+    }
+
+    const typed = response as {
+        result?: { resultCode?: unknown; resultMessage?: unknown };
+        body?: unknown;
+    };
+
+    if (!typed.result || typeof typed.result !== "object") {
+        return false;
+    }
+
+    if (typeof typed.result.resultCode !== "number") {
+        return false;
+    }
+
+    if ("body" in typed && typed.body !== undefined && typeof typed.body !== "string") {
+        return false;
+    }
+
+    return true;
+}
+
 function JoinForm() {
     const [name, setName] = useState('');
     const [email, setEmail] = useState('');
@@ -74,33 +119,58 @@ function JoinForm() {
     }
   
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
+        e.preventDefault();
     
-      const formData = new FormData(e.currentTarget);
-      const data = Object.fromEntries(formData.entries());
-    
-      try {
-        const response = await fetch(`${BASE_URL}/join`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(data),
-        });
-    
-        const { result,body } = await response.json();
-    
-        if (result.resultCode !== 200) {
-          alert(result.resultMessage);
-          window.location.reload();
-          return;
+        const formData = new FormData(e.currentTarget);
+        const data = buildJoinPayload(formData);
+
+        if (!isValidName(data.name) || !isValidEmail(data.email) || !isValidPassword(data.password)) {
+            alert("입력값 형식이 잘못되었습니다.");
+            return;
         }
     
-        alert(body)
-        router.push('/');
-      } catch (error) {
-        logWarn('Error submitting form:', error);
-      }
+        try {
+            const response = await fetch(`${BASE_URL}/join`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(data),
+            });
+
+            if (!response.ok) {
+                alert("회원가입 요청이 실패했습니다. 잠시 후 다시 시도해주세요.");
+                return;
+            }
+
+            const contentType = response.headers.get("content-type") || "";
+            if (!contentType.includes("application/json")) {
+                throw new Error("Invalid response content type");
+            }
+
+            const text = await response.text();
+            if (!text.trim()) {
+                throw new Error("Empty response body");
+            }
+
+            const parsed = JSON.parse(text);
+            if (!isValidJoinResponsePayload(parsed)) {
+                throw new Error("Invalid API response format");
+            }
+
+            const { result, body } = parsed;
+
+            if (result.resultCode !== 200) {
+                alert("회원가입 처리에 실패했습니다. 입력값을 다시 확인해주세요.");
+                return;
+            }
+
+            alert(typeof body === "string" ? body : "회원가입이 완료되었습니다.");
+            router.push("/");
+        } catch (error) {
+            logWarn("Join request error", error);
+            alert("회원가입 처리 중 오류가 발생했습니다.");
+        }
     };
 
   return (

--- a/src/app/(user)/login/LoginForm.tsx
+++ b/src/app/(user)/login/LoginForm.tsx
@@ -5,6 +5,50 @@ import { useLoginContext } from "@/app/(context)/LoginContext";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import { logWarn, logInfo } from "@/app/(common)/safeLogger";
+
+type LoginPayload = {
+    username: string;
+    password: string;
+};
+
+function trimText(value: string): string {
+    return value.trim();
+}
+
+function buildLoginPayload(formData: FormData): LoginPayload {
+    return {
+        username: trimText(String(formData.get("username") ?? "")),
+        password: trimText(String(formData.get("password") ?? "")),
+    };
+}
+
+function isSafeLoginPayload(payload: LoginPayload): boolean {
+    return payload.username.length >= 3 && payload.password.length >= 8;
+}
+
+function extractSafeErrorMessage(rawValue: string | null): string {
+    if (!rawValue) {
+        return "로그인 처리 중 오류가 발생했습니다.";
+    }
+
+    const decoded = safeDecodeURIComponent(rawValue);
+    const sanitized = decoded
+        .replace(/[\r\n]/g, " ")
+        .slice(0, 100);
+
+    return /token|password|secret|credential|session/i.test(sanitized)
+        ? "로그인 처리 중 오류가 발생했습니다."
+        : sanitized;
+}
+
+function safeDecodeURIComponent(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return "로그인 처리 중 오류가 발생했습니다.";
+    }
+}
 
 function LoginForm() {
    const router = useRouter();
@@ -13,7 +57,13 @@ function LoginForm() {
    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         const formData = new FormData(e.currentTarget);
-        const data = Object.fromEntries(formData.entries());
+        const payload = buildLoginPayload(formData);
+
+        if (!isSafeLoginPayload(payload)) {
+            logInfo("Login validation failed");
+            alert("아이디 또는 비밀번호 형식이 올바르지 않습니다.");
+            return;
+        }
         
        try {
           const response = await fetch(`${BASE_URL}/login`, {
@@ -21,7 +71,7 @@ function LoginForm() {
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify(data),
+            body: JSON.stringify(payload),
             credentials: 'include'
           });
           
@@ -29,11 +79,15 @@ function LoginForm() {
                 setIsLogin(true);
                 router.push('/');
             } else {
-                alert('Login failed. Please check your credentials');
-                window.location.reload();
+                alert('로그인에 실패했습니다. 다시 시도해주세요.');
+                if (response.status >= 500) {
+                    logWarn("Login request failed with server error", response.status);
+                }
+                return;
             }
         } catch (error) {
-             alert('Error submitting form: ' + error);
+            logWarn("Login request error", error);
+            alert("로그인 처리 중 오류가 발생했습니다.");
         }
    }
 
@@ -45,22 +99,13 @@ function LoginForm() {
     window.location.href = BASE_URL + "/oauth2/authorization/google";
    }
 
-   const getData = () => {
-    fetch(BASE_URL + "/my", {
-      method: 'GET',
-      credentials: 'include'
-    })
-    .then(res => res.json())
-    .then(data => { alert(data); })
-    .catch(error => alert(error));
-   }
-
    const showErrorAlert = () => {
      const urlParams = new URLSearchParams(window.location.search);
      const error = urlParams.get("error");
 
      if (error) {
-       alert(decodeURIComponent(error)); // 에러 메시지를 alert로 표시
+       const message = extractSafeErrorMessage(error);
+       alert(message);
      }
    };
 


### PR DESCRIPTION
## 요약
- 보안 에픽(#29) 하위작업 #76~#80을 단일 PR로 통합 반영
  - 의존성 취약점 점검 스크립트 및 산출물 등록
  - 로그인/세션/토큰 처리 경계 보강
  - 입력 값 정규화 및 응답 파싱/형식 검증 강화
  - 로그 민감정보 마스킹
  - 민감정보/오류 메시지 노출 최소화

## 체크리스트
- [x] `npm run check:security:report`
- [x] `npm run check:deps-compat`
- [x] CI/GitHub Actions 보안 워크플로우 반영
  - `.github` 경로는 현재 저장소 `.gitignore` 대상이라 현재 PR에서 추적되지 않음

## 산출물
- `docs/security-hardening-checklist.md`
- `docs/security-reports/security-audit-latest.md`
- `docs/security-reports/security-audit-latest.json`
- `scripts/security-audit.mjs`

Closes #76
Closes #77
Closes #78
Closes #79
Closes #80